### PR TITLE
Exclude specified paths from watcher.

### DIFF
--- a/util.js
+++ b/util.js
@@ -1,0 +1,26 @@
+var chalk = require('chalk'),
+	_ = require('lodash');
+
+module.exports = {
+
+	collect: function collect(val, memo) {
+		memo.push(val);
+		return memo;
+	},
+
+	log: {
+		PREFIX: '[watch-exec] ',
+		info: function(msg) {
+			msg = this.PREFIX + msg;
+			console.log.apply(console, [chalk.yellow(msg)].concat(_.rest(arguments)));
+		},
+		success: function (msg) {
+			msg = this.PREFIX + msg;
+			console.log.apply(console, [chalk.green(msg)].concat(_.rest(arguments)));
+		},
+		warn: function (msg) {
+			msg = this.PREFIX + msg;
+			console.log.apply(console, [chalk.black.bgRed(msg)].concat(_.rest(arguments)));
+		}
+	}
+};

--- a/watch-exec.js
+++ b/watch-exec.js
@@ -26,7 +26,7 @@ program
 	.option('-n, --notify', 'show desktop notifications')
 	.parse(process.argv);
 
-if (!program.command || !program.watch) {
+if (!program.command || !program.watch.length) {
 	program.help();
 }
 


### PR DESCRIPTION
Fixes #3.

Need to do some QA on this, but this would allow specified paths to be excluded from watch-exec via `--exclude`. I'm also hoping that another internal watching library, or a PR to node-watch, might add support for lower-level excludes. Filtering changes _after_ an event is detected isn't ideal because the system is still watching all the files, and runs into memory / OS limits.

Also adds a light utility class, and support for multiple `--watch` arguments.
